### PR TITLE
Feature/agentic workflow

### DIFF
--- a/.github/workflows/issue-triage-agent.lock.yml
+++ b/.github/workflows/issue-triage-agent.lock.yml
@@ -93,17 +93,19 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
-      # - name: Configure Git credentials
-      #   env:
-      #     REPO_NAME: ${{ github.repository }}
-      #     SERVER_URL: ${{ github.server_url }}
-      #   run: |
-      #     git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      #     git config --global user.name "github-actions[bot]"
-      #     # Re-authenticate git with GitHub token
-      #     SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-      #     git remote set-url origin "https://x-access-token:${{ github.token }}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
-      #     echo "Git configured with standard GitHub Actions identity"
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Configure Git credentials
+        env:
+          REPO_NAME: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          # Re-authenticate git with GitHub token
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${{ github.token }}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Generate agentic run info
         id: generate_aw_info
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow by ensuring the repository is checked out before configuring Git credentials. This change helps guarantee that subsequent steps have access to the repository files. 

* Workflow improvement:
  * Added a step to check out the repository using `actions/checkout@v5` in the `.github/workflows/issue-triage-agent.lock.yml` workflow.

This fixes #15 